### PR TITLE
set default_process_limit to a simple value

### DIFF
--- a/setup/mail-dovecot.sh
+++ b/setup/mail-dovecot.sh
@@ -38,7 +38,7 @@ apt_install \
 # would be 20 users). Set it to 250 times the number of cores this
 # machine has, so on a two-core machine that's 500 processes/100 users).
 tools/editconf.py /etc/dovecot/conf.d/10-master.conf \
-	default_process_limit=$(echo "`nproc` * 250" | bc)
+	default_process_limit=1024
 
 # The inotify `max_user_instances` default is 128, which constrains
 # the total number of watched (IMAP IDLE push) folders by open connections.


### PR DESCRIPTION
This is the simplest way to unbreak `readable_bash.py`.  With this change, it runs to completion and good docs are generated.

I'm not sure about a heuristic based on the number of cores anyway...  My 8GB dedicated box shows 2 cores and my 1GB VPS shows 4.

This PR is speculative.  If you do want to keep the computation, I can try to figure out how to make modgrammar happy with the `$(...)` construct.  But it's going to take longer.  :)
